### PR TITLE
Force update symlink to pytorch templates

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -38,7 +38,7 @@ function(GEN_XPU file_yaml)
     file(TO_NATIVE_PATH "${CMAKE_SOURCE_DIR}/aten/src/ATen/templates" SrcPATH)
     execute_process(COMMAND cmd /c xcopy ${SrcPATH} ${DestPATH} /E /H /C /I /Y > nul)
   else()
-    execute_process(COMMAND ln -s ${CMAKE_SOURCE_DIR}/aten/src/ATen/templates ${CODEGEN_XPU_YAML_DIR}) # soft link to pytorch templates
+    execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/aten/src/ATen/templates ${CODEGEN_XPU_YAML_DIR}) # soft link to pytorch templates
   endif()
 
   set(XPU_CODEGEN_COMMAND


### PR DESCRIPTION
Makes sure symlink uses current path to pytorch template folder.
```
-- Found SYCL: /lus/flare/projects/Aurora_deployment/pkourdis/soft/oneapi/2025.1.0.489/compiler/2025.1/include;/lus/flare/projects/Aurora_deployment/pkourdis/soft/oneapi/2025.1.0.489/compiler/2025.1/include/sycl;/lus/flare/projects/Aurora_deployment/pkourdis/soft/oneapi/2025.1.0.489/compiler/2025.1/include/sycl (found version "20250100")
24.35.30872
-- USE_ONEMKL is set to 1
-- Compile Intel GPU AOT Targets for pvc
ln: failed to create symbolic link '/home/pkourdis/pytorch/third_party/torch-xpu-ops/yaml/templates': File exists
Please install clang-format-12 before contributing to torch-xpu-ops!
```